### PR TITLE
Fixed ArgumentOutOfRangeException while sending specific commands during jumping or falling state.

### DIFF
--- a/2023-CyFi/CyFi/Physics/Movement/Falling.cs
+++ b/2023-CyFi/CyFi/Physics/Movement/Falling.cs
@@ -37,6 +37,8 @@ public class Falling : BaseState
             case InputCommand.DIGDOWN:
             case InputCommand.DIGLEFT:
             case InputCommand.DIGRIGHT:
+            case InputCommand.STEAL:
+            case InputCommand.RADAR:
                 break;
             default:
                 throw new ArgumentOutOfRangeException(nameof(inputCommand), inputCommand, null);

--- a/2023-CyFi/CyFi/Physics/Movement/Jumping.cs
+++ b/2023-CyFi/CyFi/Physics/Movement/Jumping.cs
@@ -42,6 +42,8 @@ public class Jumping : BaseState
             case InputCommand.DIGDOWN:
             case InputCommand.DIGLEFT:
             case InputCommand.DIGRIGHT:
+            case InputCommand.STEAL:
+            case InputCommand.RADAR:
                 break;
             default:
                 throw new ArgumentOutOfRangeException(nameof(inputCommand), inputCommand, null);


### PR DESCRIPTION
Hi There,

Sending either a STEAL or RADAR command while in a Jumping or Falling state would cause an ArgumentOutOfRangeException  to occur.

Added the required case entries to each of the inputCommand switches so the commands are handled properly.