### PR TITLE
Fixed matches running longer than the MaxTicks value specified in appsettings.

### DIFF
--- a/2023-CyFi/CyFi/CyFiEngine.cs
+++ b/2023-CyFi/CyFi/CyFiEngine.cs
@@ -123,8 +123,12 @@ namespace CyFi
 
         private void GameLoop()
         {
-            //Send updated bot state
+            if (cyFiState.Tick >= GameSettings.MaxTicks)
+            {
+                GracefulShutdown();
+            }
 
+            //Send updated bot state
             Logger.Log(LogLevel.Information, $"Tick: {cyFiState.Tick} ************************************************* ");
 
             List<BotStateDTO> botStates = new List<BotStateDTO>();
@@ -239,11 +243,6 @@ namespace CyFi
                 bot.TotalPoints += 20;
                 IGameLogger<CyFiState>.File(null, 2);
                 EndGame();
-            }
-
-            if (cyFiState.Tick > GameSettings.MaxTicks)
-            {
-                GracefulShutdown();
             }
         }
 


### PR DESCRIPTION
Hi There,

As the title states, currently it is possible for matches to run longer than the MaxTicks value specified in appsettings.

The cause of this is MaxTicks only being checked when bots move to higher levels.

This change moves the MaxTicks check to the start of the game loop so it is checked at the start of every tick.