### PR TITLE
fixed game loop and published states

### DIFF
--- a/2023-CyFi/CyFi/Runner/RunnerHub.cs
+++ b/2023-CyFi/CyFi/Runner/RunnerHub.cs
@@ -72,12 +72,13 @@ namespace CyFi.Runner
         /// <param name="gameObject"></param>
         /// <returns></returns>
         /// 
-        public async Task PublishBotStates(List<BotStateDTO> botStates)
+        public async Task<bool> PublishBotStates(List<BotStateDTO> botStates)
         {
             foreach (var botState in botStates)
             {
                 await Clients.Client(botState.ConnectionId).SendAsync("ReceiveBotState", botState);
             }
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
Updated runner hub PublishBotStates to return a value when all bot states are published, and added a check that solved all my timing issues to ensure only one GameLoop runs at a time