### PR TITLE
Fixed loop with multiple bots

### DIFF
--- a/2023-CyFi/CyFi/CyFiEngine.cs
+++ b/2023-CyFi/CyFi/CyFiEngine.cs
@@ -322,10 +322,16 @@ namespace CyFi
             TickTimer.AutoReset = true;
         }
 
+ bool inLoop = false;
         private void OnTimedEvent(object? sender, ElapsedEventArgs e)
         {
-            Console.WriteLine("The Elapsed event was raised at {0}", e.SignalTime);
-            GameLoop();
+             if (!inLoop)
+            {
+                inLoop = true;
+                Console.WriteLine("The Elapsed event was raised at {0}", e.SignalTime);
+                GameLoop();
+                inLoop = false;
+            }
         }
     }
 }


### PR DESCRIPTION
the engine still overlaps ticks adding a simple in loop check it processes 4 bots without issue